### PR TITLE
added support for different environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,30 @@
 mongoose-migration
+==================
+
 Data migration tool for Mongoose
 
-Installation
+## Installation
 
 Run the following command to install it:
 
+```console
 npm install mongoose-migration --save
-Usage
+```
 
-Init configuration
+## Usage
 
-The following command should be executed a single time on the project root directory. It will create the .migrate.js configuration file.
+### Init configuration
 
+The following command should be executed a single time on the project root directory. It will create the `.migrate.js` configuration file.
+
+```console
 migrate init
+```
+
 After creating it you need to edit and add the path to your models.
 
 Example:
-
+```js
 var CONFIG = {
   "basepath": "migrations",
   "connection": "mongodb://localhost/db",
@@ -26,25 +34,33 @@ var CONFIG = {
 }
 
 module.exports = CONFIG;
+```
 
-Note that on the previous example models/user.js is the model definition file. This file should exports the mongoose model definition.
+Note that on the previous example `models/user.js` is the model definition file. This file should exports the mongoose model definition.
 
-model/users.js example:
-
+`model/users.js` example:
+```javascript
 ...
 module.exports = mongoose.model('User', schema);
-Create a migration
+```
 
+### Create a migration
+
+```console
 migrate create <description>
-Example:
+```
 
+Example:
+```console
 migrate create "Add createdAt field to users collection"
-Edit Migration File
+```
 
-Open up your migration file (created on the previous step). It should have a default up and down function.
+### Edit Migration File
+
+Open up your migration file (created on the previous step). It should have a default `up` and `down` function.
 
 Example:
-
+```javascript
 exports.up = function(next) {
   next();
 };
@@ -52,10 +68,12 @@ exports.up = function(next) {
 exports.down = function(next) {
   next();
 };
-Note: To load a mongoose model defined on your configuration file you should call this.model(<model name>)
+```
+
+Note: To load a mongoose model defined on your configuration file you should call `this.model(<model name>)`
 
 Example:
-
+```javascript
 exports.up = function(next) {
   this
     .model('User')
@@ -101,42 +119,68 @@ exports.down = function(next) {
       }
     );
 };
-Perform Migration
+```
 
+### Perform Migration
+
+```console
 migrate
+```
 or
-
+```console
 migrate up [number of migrations to perform]
-Note: By default migrate will execute all migrations created until now. However migrate up will only execute one migration.
+```
 
-Rollback Migration
+Note: By default `migrate` will execute all migrations created until now. However `migrate up` will only execute one migration.
 
+### Rollback Migration
+
+```console
 migrate down
+```
 or
-
+```console
 migrate down [number of migrations to rollback]
+```
 
-Note that the first time you migrate up or down a file called .timestamp.json will be created. I suggest you to ignore it in your .gitignore to have migration working on different machines.
+Note: the first time you migrate up or down a file called .timestamp.json will be created. I suggest you to ignore it in your .gitignore to have migration working on different machines.
 
-Help
+### Help
 
+```console
 migrate -h
-Todo
+```
 
-Add environments (dev, production) on the configuration file
-Add migrate to [timestamp]
-Add tests
-Contributing
-For contributing, open an issue and/or a pull request.
+## Todo
 
-License
+- Add environments (dev, production) on the configuration file
+- Add `migrate to [timestamp]`
+- Add tests
+
+# Contributing
+
+For contributing, [open an issue](https://github.com/mccraveiro/mongoose-migration/issues) and/or a [pull request](https://github.com/mccraveiro/mongoose-migration/pulls).
+
+## License
 
 The MIT License (MIT)
 
 Copyright (c) 2014 mccraveiro
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,65 +1,50 @@
 mongoose-migration
-==================
-
 Data migration tool for Mongoose
 
-## Installation
+Installation
 
 Run the following command to install it:
 
-```console
 npm install mongoose-migration --save
-```
+Usage
 
-## Usage
+Init configuration
 
-### Init configuration
+The following command should be executed a single time on the project root directory. It will create the .migrate.js configuration file.
 
-The following command should be executed a single time on the project root directory. It will create the `.migrate.json` configuration file.
-
-```console
 migrate init
-```
-
 After creating it you need to edit and add the path to your models.
 
 Example:
-```json
-{
+
+var CONFIG = {
   "basepath": "migrations",
   "connection": "mongodb://localhost/db",
-  "current_timestamp": 0,
   "models": {
     "User": "models/user.js"
   }
 }
-```
 
-Note that on the previous example `models/user.js` is the model definition file. This file should exports the mongoose model definition.
+module.exports = CONFIG;
 
-`model/users.js` example:
-```javascript
+Note that on the previous example models/user.js is the model definition file. This file should exports the mongoose model definition.
+
+model/users.js example:
+
 ...
 module.exports = mongoose.model('User', schema);
-```
+Create a migration
 
-### Create a migration
-
-```console
 migrate create <description>
-```
-
 Example:
-```console
+
 migrate create "Add createdAt field to users collection"
-```
+Edit Migration File
 
-### Edit Migration File
-
-Open up your migration file (created on the previous step). It should have a default `up` and `down` function.
+Open up your migration file (created on the previous step). It should have a default up and down function.
 
 Example:
-```javascript
+
 exports.up = function(next) {
   next();
 };
@@ -67,12 +52,10 @@ exports.up = function(next) {
 exports.down = function(next) {
   next();
 };
-```
-
-Note: To load a mongoose model defined on your configuration file you should call `this.model(<model name>)`
+Note: To load a mongoose model defined on your configuration file you should call this.model(<model name>)
 
 Example:
-```javascript
+
 exports.up = function(next) {
   this
     .model('User')
@@ -118,66 +101,42 @@ exports.down = function(next) {
       }
     );
 };
-```
+Perform Migration
 
-### Perform Migration
-
-```console
 migrate
-```
 or
-```console
+
 migrate up [number of migrations to perform]
-```
+Note: By default migrate will execute all migrations created until now. However migrate up will only execute one migration.
 
-Note: By default `migrate` will execute all migrations created until now. However `migrate up` will only execute one migration.
+Rollback Migration
 
-### Rollback Migration
-
-```console
 migrate down
-```
 or
-```console
+
 migrate down [number of migrations to rollback]
-```
 
-### Help
+Note that the first time you migrate up or down a file called .timestamp.json will be created. I suggest you to ignore it in your .gitignore to have migration working on different machines.
 
-```console
+Help
+
 migrate -h
-```
+Todo
 
-## Todo
+Add environments (dev, production) on the configuration file
+Add migrate to [timestamp]
+Add tests
+Contributing
+For contributing, open an issue and/or a pull request.
 
-- Add environments (dev, production) on the configuration file
-- Add `migrate to [timestamp]`
-- Add tests
-
-# Contributing
-
-For contributing, [open an issue](https://github.com/mccraveiro/mongoose-migration/issues) and/or a [pull request](https://github.com/mccraveiro/mongoose-migration/pulls).
-
-## License
+License
 
 The MIT License (MIT)
 
 Copyright (c) 2014 mccraveiro
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -7,12 +7,14 @@ var slug = require('slug');
 var path = require('path');
 var fs = require('fs');
 
+var config_path = process.cwd() + '/.migrate.js';
+
 var CONFIG;
 
 // The models should be shared between migration files
+var timestamp_path = process.cwd() + '/.timestamp.json';
 
-var models_config_path = process.cwd() + '/.migrate-models.json';
-var MODELS_CONFIG;
+var timestamp_CONFIG;
 
 program
   .command('init')
@@ -36,11 +38,7 @@ program
 
 program.version(require('../package.json').version);
 
-// Specify an environment appending -e <environment_name> or --environment <environment_name> to the command
-
-program
-  .option('-e, --environment <name>', 'add the environment')
-  .parse(process.argv);
+program.parse(process.argv);
   
 
 // Default command ?
@@ -63,53 +61,31 @@ function success(msg) {
 
 function loadConfiguration() {
   try {
-    console.log(getConfigFilePath());
-    return require(getConfigFilePath());
+    return require(config_path);
   } catch (e) {
-    if (program.environment) {
-      error('Missing ' + getConfigFileName() + ' file. Type `migrate init --environment ' + program.environment + '` to create.');
+      error('Missing ' + config_path + ' file. Type `migrate init` to create.');
     }
-    else {
-      error('Missing ' + getConfigFileName() + ' file. Type `migrate init` to create.');
-    }
-  }
 }
 
-function loadModelsConfiguration() {
+function timestampConfiguration() {
   try {
-    return require(models_config_path);
+    return require(timestamp_path);
   } catch (e) {
-    if (program.environment) {
-      error('Missing .migrate-models.json file. Type `migrate init --environment ' + program.environment + '` to create.');
-    }
-    else {
-      error('Missing .migrate-models.json file. Type `migrate init` to create.');
-    }
+    var data = JSON.stringify({ current_timestamp: 0 }, null, 2);
+      fs.writeFileSync(timestamp_path, data);
   }
 }
 
 function updateTimestamp(timestamp, cb) {
-  CONFIG.current_timestamp = timestamp;
-  var data = JSON.stringify(CONFIG, null, 2);
-  fs.writeFile(getConfigFilePath(), data, cb);
+  timestamp_CONFIG.current_timestamp = timestamp;
+  var data = JSON.stringify(timestamp_CONFIG, null, 2);
+  fs.writeFile(timestamp_path, data, cb);
 }
 
 function init() {
   
-  if (!fs.existsSync(models_config_path)) {
-    MODELS_CONFIG = {
-      models: {}
-    };
-    
-    var data = JSON.stringify(MODELS_CONFIG, null, 2);
-    console.log(models_config_path);
-    fs.writeFileSync(models_config_path, data);
-
-    success(models_config_path + ' file created!\nEdit it to include your models definitions');
-  }
-  
-  if (fs.existsSync(getConfigFilePath())) {
-    error(getConfigFileName() + ' already exists!');
+  if (fs.existsSync(config_path)) {
+    error(config_path + ' already exists!');
   }
 
   var schema = {
@@ -129,17 +105,15 @@ function init() {
 
   prompt.start();
   prompt.get(schema, function (error, result) {
-    CONFIG = {
-      basepath: result.basepath,
-      connection: result.connection,
-      current_timestamp: 0
-    };
 
-    var data = JSON.stringify(CONFIG, null, 2);
+    var data = fs.readFileSync(path.normalize(__dirname + '/../template/config.js'), 'ascii');
+    data = data
+      .replace('MIGRATION_KEY', result.basepath)
+      .replace('CONNECTION_KEY', result.connection);
     
-    fs.writeFileSync(getConfigFilePath(), data);
+    fs.writeFileSync(config_path, data);
 
-    success(getConfigFileName() + ' file created!\n');
+    success(config_path + ' file created!\nEdit to add your models');
     process.exit();
   });
 }
@@ -147,7 +121,7 @@ function init() {
 function createMigration(description) {
 
   CONFIG = loadConfiguration();
-  CONFIG.models = loadModelsConfiguration().models;
+  timestamp_CONFIG = timestampConfiguration();
 
   var timestamp = Date.now();
   var migrationName = timestamp + '-' + slug(description) + '.js';
@@ -173,7 +147,6 @@ function connnectDB() {
 }
 
 function loadModel(model_name) {
-  
   return require(process.cwd() + '/' + CONFIG.models[model_name]);
 }
 
@@ -184,7 +157,7 @@ function getTimestamp(name) {
 function migrate(direction, cb, number_of_migrations) {
 
   CONFIG = loadConfiguration();
-  CONFIG.models = loadModelsConfiguration().models;
+  timestamp_CONFIG = timestampConfiguration();
   
   if (!number_of_migrations) {
     number_of_migrations = 1;
@@ -202,9 +175,9 @@ function migrate(direction, cb, number_of_migrations) {
     var timestamp = getTimestamp(migration_name);
 
     if (number_of_migrations > 0) {
-      return timestamp > CONFIG.current_timestamp;
+      return timestamp > timestamp_CONFIG.current_timestamp;
     } else if (number_of_migrations < 0) {
-      return timestamp <= CONFIG.current_timestamp;
+      return timestamp <= timestamp_CONFIG.current_timestamp;
     }
   });
 
@@ -247,15 +220,4 @@ function applyMigration(direction, name, cb) {
 
     updateTimestamp(timestamp, cb);
   }
-}
-
-function getConfigFileName() {
-  if (program.environment) {
-    return '.migrate' + '-' + program.environment + '.json';
-  }
-  return '.migrate.json';
-}
-
-function getConfigFilePath() {
-  return process.cwd() + '/' + getConfigFileName();
 }


### PR DESCRIPTION
With these version you can use the -e or --environment option to specify different environments.

'$ migrate init -e "dev"' will initialize '.migration-dev.json' file, if no environment is specified it'll initialize '.migration.json' file.

Same for the other commands:

'$ migrate -e "dev"' || '$ migrate -e "dev" up' to migrate up using the dev configurations.
'$ migrate -e "dev" down' to migrate down using the dev configurations.

Note: there is no more the models array inside the '.migration**.json' files. Instead of it there is a new file called '.migration-models.json' used to share models between all the migration configurations.
