### PR TITLE
Allow selection of config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ npm install mongoose-migration --save
 
 ### Init configuration
 
-The following command should be executed a single time on the project root directory. It will create the `.migrate.json` configuration file.
+The following command should be executed on the project root directory. It will create a configuration file with the given `config-file` name, or `.migrate.json` if not especified.
 
 ```console
-migrate init
+migrate init [config-file]
 ```
+
+With this you can have a configuration file for each environment, for example: `.migrate.dev.json` and `.migrate.prod.json`
 
 After creating it you need to edit and add the path to your models.
 
@@ -129,6 +131,10 @@ or
 ```console
 migrate up [number of migrations to perform]
 ```
+You can specify which configuration file should be loaded with `-c <file>` or `--config <file>` option. If it is not specified, `.migrate.json` will be used.
+```console
+migrate up [number of migrations to perform] -c .migrate.dev.json
+```
 
 Note: By default `migrate` will execute all migrations created until now. However `migrate up` will only execute one migration.
 
@@ -141,6 +147,10 @@ or
 ```console
 migrate down [number of migrations to rollback]
 ```
+You can specify which configuration file should be loaded with `-c <file>` or `--config <file>` option. If it is not specified, `.migrate.json` will be used.
+```console
+migrate down [number of migrations to perform] -c .migrate.dev.json
+```
 
 ### Help
 
@@ -150,7 +160,6 @@ migrate -h
 
 ## Todo
 
-- Add environments (dev, production) on the configuration file
 - Add `migrate to [timestamp]`
 - Add tests
 

--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -21,8 +21,8 @@ program
   );
 
 program
-  .command('init')
-  .description('Init migrations on current path')
+  .command('init [config-file]')
+  .description('Init migrations on current path (default = .migrate.json)')
   .action(init);
 
 program
@@ -79,11 +79,20 @@ function updateTimestamp(timestamp, cb) {
   fs.writeFile(config_path, data, cb);
 }
 
-function init() {
+function init(config_filename) {
+  // if no config_filename was passed as argument, set its
+  // value to '.migrate.json'
+  if (!config_filename) {
+    config_filename = '.migrate.json';
+  }
+
+  config_path = path.join(process.cwd(), config_filename);
+
   if (fs.existsSync(config_path)) {
     error(config_filename + ' already exists!');
   }
 
+  console.log('Configuration file to be created: ' + config_filename);
   var schema = {
     properties: {
       basepath: {

--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -9,9 +9,16 @@ var slug = require('slug');
 var path = require('path');
 var fs = require('fs');
 
-var config_filename = '.migrate.json';
-var config_path = process.cwd() + '/' + config_filename;
+var config_filename;
+var config_path;
 var CONFIG;
+
+program
+  .option(
+    '-c, --config <file>',
+    'config file for "up" and "down" commands (default = .migrate.json)',
+    '.migrate.json'
+  );
 
 program
   .command('init')
@@ -55,6 +62,10 @@ function success(msg) {
 }
 
 function loadConfiguration() {
+  // load config filename from command line options
+  config_filename = program.config;
+  config_path = path.join(process.cwd(), config_filename);
+
   try {
     return require(config_path);
   } catch (e) {


### PR DESCRIPTION
Added `-c/--config` option to specify a config file to use in `up` and `down` commands, and allow user to specify a config file in `init` command to store configuration (.migrate.json still the default)